### PR TITLE
optimize replace spaces function

### DIFF
--- a/src/routes/functions.js
+++ b/src/routes/functions.js
@@ -13,10 +13,7 @@ export function shuffleArray(array) {
     return array;
 }
 
-
-const regexSpaceBefore = /^\s+/g;
-const regexSpaceAfter = /\s+$/g;
-
 export function removeSpacesBeforeAndAfter(string) {
-    return string.replace(regexSpaceBefore,'').replace(regexSpaceAfter,'');
+  const regexSpacesBeforeOrAfter = /^\s+|\s+$/g;
+  return string.replace(regexSpacesBeforeOrAfter, '');
 }


### PR DESCRIPTION
Suggestion pour optimiser la fonction:
- utiliser une regex au lieu de deux
- mettre la regex dans le scope de la fonction (plutôt que le scope global)

Autre option fournie par JavaScript: la fonction trim() qui fait la même chose: https://www.w3schools.com/jsref/jsref_trim_string.as. :).